### PR TITLE
Fixes "List index out of range" error

### DIFF
--- a/gpt_2_simple/src/load_dataset.py
+++ b/gpt_2_simple/src/load_dataset.py
@@ -36,7 +36,8 @@ def load_dataset(enc, path, combine):
                 fp.readline()   # skip header
                 reader = csv.reader(fp)
                 for row in reader:
-                    raw_text += start_token + row[0] + end_token + "\n"
+                    if row:
+                        raw_text += start_token + row[0] + end_token + "\n"
         else:
             # Plain text
             with open(path, 'r', encoding='utf8', errors='ignore') as fp:


### PR DESCRIPTION
It was choking on empty lines that returned a value of []. Checking to see if they're not [] (which is Falsy) prevents this and allows loading of CSVs with empty rows (it will skip them).